### PR TITLE
give user a warning if IDs will collide

### DIFF
--- a/changegen/__main__.py
+++ b/changegen/__main__.py
@@ -32,7 +32,7 @@ def _get_max_ids(source_extract):
         )
     except subprocess.CalledProcessError as e:
         logging.warning(
-            "osmosis not found; unable to determine max OSM id in source extract"
+            "osmium not found; unable to determine max OSM id in source extract"
         )
         raise e
 
@@ -45,7 +45,7 @@ def _get_max_ids(source_extract):
             stderr=subprocess.PIPE,
         )
         if proc.stderr.read():
-            raise subprocess.CalledProcessError(-1, "osmosis", "Error in osmosis.")
+            raise subprocess.CalledProcessError(-1, "osmium", "Error in osmium.")
         ids[idtype.split(".")[-1]] = int(proc.stdout.read().strip())
     return ids
 

--- a/changegen/__main__.py
+++ b/changegen/__main__.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import subprocess
 import sys
 
 import click
@@ -17,6 +18,36 @@ Tony Cannistra <tony@gaiagps.com>
 Provides main changegen CLI-based entrypoint.
 
 """
+
+
+def _get_max_ids(source_extract):
+    # get the max ID from source extract using osmium
+    ## first ensure that osmium exists
+    try:
+        proc = subprocess.check_call(
+            "osmium --help",
+            shell=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError as e:
+        logging.warning(
+            "osmosis not found; unable to determine max OSM id in source extract"
+        )
+        raise e
+
+    ids = {}
+    for idtype in ["data.maxid.ways", "data.maxid.nodes", "data.maxid.relations"]:
+        proc = subprocess.Popen(
+            f"osmium fileinfo -e -g {idtype} --no-progress {source_extract}",
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if proc.stderr.read():
+            raise subprocess.CalledProcessError(-1, "osmosis", "Error in osmosis.")
+        ids[idtype.split(".")[-1]] = int(proc.stdout.read().strip())
+    return ids
 
 
 def _get_db_tables(suffix, dbname, dbport, dbuser, dbpass, dbhost):
@@ -102,6 +133,16 @@ def main(*args: tuple, **kwargs: dict):
     """
     setup_logging(debug=kwargs["debug"])
     logging.debug(f"Args: {kwargs}")
+
+    # Check for ID collisions and warn
+    try:
+        ids = _get_max_ids(kwargs["osmsrc"])
+        if any([kwargs["id_offset"] < id for id in ids.values()]):
+            logging.warning(
+                f"Chosen ID offset {kwargs['id_offset']} may cause collisions with existing OSM IDs (max IDs: {ids})."
+            )
+    except subprocess.CalledProcessError:
+        logging.error("Error checking existing OSM max ids.")
 
     new_tables = []
     for suffix in kwargs["suffix"]:

--- a/changegen/__main__.py
+++ b/changegen/__main__.py
@@ -99,6 +99,13 @@ def _get_db_tables(suffix, dbname, dbport, dbuser, dbpass, dbhost):
     show_default=True,
 )
 @click.option(
+    "--no_collisions",
+    help="Stop execution if the chosen ID offset "
+    "will cause collisions with existing OSM ids."
+    " (requires osmium).",
+    is_flag=True,
+)
+@click.option(
     "--self",
     "-si",
     help=(
@@ -138,9 +145,12 @@ def main(*args: tuple, **kwargs: dict):
     try:
         ids = _get_max_ids(kwargs["osmsrc"])
         if any([kwargs["id_offset"] < id for id in ids.values()]):
-            logging.warning(
-                f"Chosen ID offset {kwargs['id_offset']} may cause collisions with existing OSM IDs (max IDs: {ids})."
-            )
+            _log_text = f"Chosen ID offset {kwargs['id_offset']} may cause collisions with existing OSM IDs (max IDs: {ids})."
+            if kwargs["no_collisions"]:
+                logging.fatal(_log_text)
+                sys.exit(-1)
+            else:
+                logging.warning(_log_text)
     except subprocess.CalledProcessError:
         logging.error("Error checking existing OSM max ids.")
 


### PR DESCRIPTION
Gives user a warning if the ID offset they've chosen collides with any IDs in the source extract. 

Also provides a `--no_collisions` flag which `sys.exit`s if there will be collisions, instead of just warning user. 

Requires `osmium`, so I put a bunch of error checking that avoids crashes if it doesn't exist on the system. 