### PR TITLE
Implement deletion and metadata modification in changefile output

### DIFF
--- a/changegen/__main__.py
+++ b/changegen/__main__.py
@@ -48,6 +48,16 @@ def _get_db_tables(suffix, dbname, dbport, dbuser, dbpass, dbhost):
     multiple=True,
 )
 @click.option(
+    "--deletions",
+    help=(
+        "Name of table containing OSM IDs for which <delete> tags "
+        " should be created in the resulting changefile. Table must "
+        " contain <osm_id> column. Can be passed multiple times."
+    ),
+    multiple=True,
+    default=[],
+)
+@click.option(
     "-e",
     "--existing",
     help=(
@@ -142,6 +152,7 @@ def main(*args: tuple, **kwargs: dict):
         generate_changes(
             table,
             kwargs["existing"],
+            kwargs["deletions"],
             kwargs["dbname"],
             kwargs["dbport"],
             kwargs["dbuser"],

--- a/changegen/__main__.py
+++ b/changegen/__main__.py
@@ -71,7 +71,7 @@ def _get_db_tables(suffix, dbname, dbport, dbuser, dbpass, dbhost):
     "-m",
     "--modify_meta",
     help=(
-        "Create <modify> nodes instead of create nodes "
+        "Create <modify> tags in changefile, instead of create nodes "
         "for all tables specified by --suffix. Only applies to "
         "Ways with with modified metadata, not geometries (see full help)."
     ),

--- a/changegen/__main__.py
+++ b/changegen/__main__.py
@@ -146,7 +146,7 @@ def main(*args: tuple, **kwargs: dict):
 
     if kwargs["modify_meta"] and kwargs["existing"]:
         raise RuntimeError("--modify_meta cannot be used with --existing.")
-    if not kwargs["modify_meta"] and not kwargs["existing"]:
+    if not kwargs["deletions"] and not kwargs["modify_meta"] and not kwargs["existing"]:
         raise RuntimeError("Need either --modify_meta or --existing.")
 
     for table in new_tables:

--- a/changegen/__main__.py
+++ b/changegen/__main__.py
@@ -7,6 +7,7 @@ import psycopg2 as psy
 
 from . import PACKAGE_NAME
 from .generator import generate_changes
+from .generator import generate_deletions
 from .util import setup_logging
 
 """
@@ -152,7 +153,6 @@ def main(*args: tuple, **kwargs: dict):
         generate_changes(
             table,
             kwargs["existing"],
-            kwargs["deletions"],
             kwargs["dbname"],
             kwargs["dbport"],
             kwargs["dbuser"],
@@ -165,6 +165,20 @@ def main(*args: tuple, **kwargs: dict):
             id_offset=kwargs["id_offset"],
             self_intersections=kwargs["self"],
             modify_only=kwargs["modify_meta"],
+        )
+
+    for table in kwargs["deletions"]:
+        generate_deletions(
+            table,
+            "osm_id",
+            kwargs["dbname"],
+            kwargs["dbport"],
+            kwargs["dbuser"],
+            kwargs["dbpass"] if kwargs["dbpass"] != "" else None,
+            kwargs["dbhost"],
+            kwargs["osmsrc"],
+            os.path.join(str(kwargs["o"]), f"{table}.osc"),
+            compress=kwargs["compress"],
         )
 
 

--- a/changegen/changewriter.py
+++ b/changegen/changewriter.py
@@ -161,3 +161,14 @@ class OSMChangeWriter(object):
                     write_osm_object(e, writer)
             writer.flush()
         self._data_written = True
+
+    def add_delete(self, elementlist):
+        """Creates a <delete> element containing
+        all elements in elementlist"""
+
+        with self.xmlwriter as writer:
+            with writer.element("delete"):
+                for e in elementlist:
+                    write_osm_object(e, writer)
+                writer.flush()
+        self._data_written = True

--- a/changegen/db.py
+++ b/changegen/db.py
@@ -61,6 +61,23 @@ class OGRDBReader(object):
             )
         return _r.GetNextFeature()
 
+    def get_all_ids_for_layer(self, layer, id_fieldname="osm_id"):
+        """
+        Retrieves all unique values of `id_fieldname` within `layer`.
+        """
+        id_query = f"SELECT distinct {id_fieldname} FROM {layer}"
+
+        logging.debug(f"Executing SQL: {id_query}")
+        queryLayer = self.data.ExecuteSQL(id_query)
+        idlist = []
+
+        _id = queryLayer.GetNextFeature()
+        while _id:
+            idlist.append(_id.GetFieldAsString(0))
+            _id = queryLayer.GetNextFeature()
+
+        return idlist
+
     def intersections(
         self,
         new_layer,

--- a/changegen/generator.py
+++ b/changegen/generator.py
@@ -86,6 +86,12 @@ def _nodes_for_intersections(ilayer, idgen):
     return nodes
 
 
+def _get_deleted_way_ids(table, db):
+    """Returns OSM ids present in osm_id column of table as list."""
+    deletions_iter = db.get_layer_iter(table)
+    return [_f.GetFieldAsString(_f.GetFieldIndex("osm_id")) for _f in deletions_iter]
+
+
 def _generate_intersection_db(layer, others, db, idgen, self=False):
     """
     Returns an rtree spatial index containing Nodes
@@ -418,6 +424,7 @@ def _generate_ways_and_nodes(
 def generate_changes(
     table,
     others,
+    deletions,
     dbname,
     dbport,
     dbuser,
@@ -555,11 +562,16 @@ def generate_changes(
     # Write all modified ways with intersections
     # Because we have to re-generate nodes for all points
     # within the intersecting linestrings, we write
-    # those as new nodes.
-    logging.info(f"Retrieving existing Node IDs for modified ways (file: {osmsrc})")
+    # those as new nodes. We also get deletion ways +
+    # their corresponding nodes here too, to save time.
+    logging.info(f"Retrieving deletion nodes for tables: {deletions}")
+    deletion_way_ids = [_get_deleted_way_ids(table, db_reader) for table in deletions]
+    logging.info(
+        f"Retrieving existing Node IDs for modified and deleted ways (file: {osmsrc})"
+    )
     modified_ways = []
     way_node_map = _get_way_node_map(
-        osmsrc, list(chain.from_iterable(intersecting_idlists))
+        osmsrc, list(chain.from_iterable(intersecting_idlists + deletion_way_ids))
     )
 
     # only if there are intersections
@@ -604,6 +616,15 @@ def generate_changes(
 
     # Write all intersecting nodes to file:
     change_writer.add_create(intersection_nodes)
+
+    # Write deletions, including ways + nodes
+    ids_to_delete = []
+    for way_id in chain.from_iterable(deletion_way_ids):
+        # constituent node ids
+        ids_to_delete.extend(way_node_map[way_id])
+        # way id itself
+        ids_to_delete.append(way_id)
+    change_writer.add_delete(ids_to_delete)
 
     change_writer.close()
 


### PR DESCRIPTION
This PR adds two major modifications which support a more complete of conflation tasks:
* adds a `--deletions` option that enables folks to specify the name of a table (or tables) that contain the OSM IDs of Ways that should have a corresponding `<delete>` node in the output changefile. (Closes #7) 
* adds a `--modify_meta` option that provides support for the creation of changefiles that represent _modifications to existing Way metadata_ (e.g. activity classifications) 

### Deletion Details

For each Way to be deleted we also ensure that any corresponding Nodes are also deleted. This is maybe not a good idea, or maybe should be optional, because there may be situations in which deleting the node will create an issue with intersections: if a node is deleted is shared with another Way, that Way will be affected/will be shorter. It's probably safest to not delete nodes. 

We consider <delete> generation to be a completely different procedure from create or modify, so it occurs as a separate step . this allows for changefiles containing <create>/<modify> tags to be created separately (but w/ the same CLI invocation) as changefiles with <delete> tags.

### Metadata Modification Details

Using the `--modify_meta` tag 
* Disables support for intersection node creation (via `--existing` -- error if provided)
* Writes `<modify>` tags instead of `<create>` tags for all features in the provided table, using metadata in DB
* Ensures existing OSM IDs (for both Way and the constituent Nodes) are preserved
* **only supports Ways with modified metadata**

This PR is a required step for https://github.com/trailbehind/USFSConflation/issues/29 