### PR TITLE
Add support for polygons in changefiles (as `Way`s)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,10 +19,6 @@ repos:
     hooks:
       - id: reorder-python-imports
         language_version: python3
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.782
-    hooks:
-      - id: mypy
   - repo: https://github.com/prettier/prettier
     rev: 2.1.2
     hooks:

--- a/changegen/__main__.py
+++ b/changegen/__main__.py
@@ -65,7 +65,6 @@ def _get_db_tables(suffix, dbname, dbport, dbuser, dbpass, dbhost):
     help=(
         "Table of geometries to use when determining whether existing"
         " features must be altered to include linestring intersections."
-        " Cannot be used with --no_intersections."
     ),
     multiple=True,
     default=[],
@@ -137,8 +136,6 @@ def main(*args: tuple, **kwargs: dict):
             )
         )
     logging.info(f"Found tables in db: {new_tables}")
-    if kwargs["no_intersections"]:
-        logging.info("Skipping intersections. --existing flags ignored.")
 
     max_nodes_per_way = kwargs["max_nodes_per_way"]
     if str(max_nodes_per_way).lower() == "none":

--- a/changegen/__main__.py
+++ b/changegen/__main__.py
@@ -208,14 +208,11 @@ def main(*args: tuple, **kwargs: dict):
 
     max_nodes_per_way = kwargs["max_nodes_per_way"]
     if str(max_nodes_per_way).lower() == "none":
-        print("setting to inf")
         max_nodes_per_way = math.inf
     elif max_nodes_per_way == None:
         max_nodes_per_way = 2000
     if kwargs["modify_meta"] and kwargs["existing"]:
         raise RuntimeError("--modify_meta cannot be used with --existing.")
-    if not kwargs["deletions"] and not kwargs["modify_meta"] and not kwargs["existing"]:
-        raise RuntimeError("Need either --modify_meta or --existing.")
 
     for table in new_tables:
         generate_changes(
@@ -233,7 +230,7 @@ def main(*args: tuple, **kwargs: dict):
             neg_id=kwargs["neg_id"],
             id_offset=kwargs["id_offset"],
             self_intersections=kwargs["self"],
-            max_nodes_per_way=max_nodes_per_way,
+            max_nodes_per_way=int(max_nodes_per_way),
             modify_only=kwargs["modify_meta"],
         )
 

--- a/changegen/__main__.py
+++ b/changegen/__main__.py
@@ -8,7 +8,6 @@ import psycopg2 as psy
 
 from . import PACKAGE_NAME
 from .generator import generate_changes
-from .util import NotRequiredIf
 from .util import setup_logging
 
 
@@ -61,14 +60,6 @@ def _get_db_tables(suffix, dbname, dbport, dbuser, dbpass, dbhost):
     default=[],
 )
 @click.option(
-    "--no_intersections",
-    help=(
-        "Do not attempt to find intersections with existing data. "
-        "Any table names passed with -e will be ignoored."
-    ),
-    is_flag=True,
-)
-@click.option(
     "-e",
     "--existing",
     help=(
@@ -77,8 +68,7 @@ def _get_db_tables(suffix, dbname, dbport, dbuser, dbpass, dbhost):
         " Cannot be used with --no_intersections."
     ),
     multiple=True,
-    cls=NotRequiredIf,
-    not_required_if="no_intersections",
+    default=[],
 )
 @click.option("-o", "-outdir", help="Directory to output change files to.", default=".")
 @click.option("--compress", help="gzip-compress xml output", is_flag=True)
@@ -160,7 +150,7 @@ def main(*args: tuple, **kwargs: dict):
     for table in new_tables:
         generate_changes(
             table,
-            kwargs["existing"] if not kwargs["no_intersections"] else [],
+            kwargs["existing"],
             kwargs["deletions"],
             kwargs["dbname"],
             kwargs["dbport"],

--- a/changegen/__main__.py
+++ b/changegen/__main__.py
@@ -145,6 +145,7 @@ def _get_db_tables(suffix, dbname, dbport, dbuser, dbpass, dbhost):
         " If a way exceeds this value "
         " it will be subdivided into smaller ways. Pass `none` for no limit."
     ),
+    default="2000",
 )
 @click.option("--osmsrc", help="Source OSM PBF File path", required=True)
 @click.argument("dbname", default=os.environ.get("PGDATABASE", "conflate"))

--- a/changegen/changewriter.py
+++ b/changegen/changewriter.py
@@ -56,10 +56,15 @@ def write_osm_object(osm, writer):
     try:
         attrs = dict(osm._asdict())
         objtype = type(osm).__name__.lower()
+        # we don't want to write tags, nds, or members in the main element
+        # for objects. They'll get written as child elements below.
         attrs.pop("tags")
         if hasattr(osm, "nds"):
             attrs.pop("nds")
+        if hasattr(osm, "members"):
+            attrs.pop("members")
         attrs = {k: str(attrs[k]) for k in attrs.keys()}
+
         with writer.element(objtype, **attrs):
             # special cases for objects with
             # <tags> or <nds> (ways). Write as sub-elems
@@ -73,7 +78,10 @@ def write_osm_object(osm, writer):
                 for member in osm.members:
                     writer.write(
                         etree.Element(
-                            "member", ref=member.ref, type=member.type, role=member.role
+                            "member",
+                            ref=str(member.ref),
+                            type=member.type,
+                            role=member.role,
                         )
                     )
             writer.flush()

--- a/changegen/changewriter.py
+++ b/changegen/changewriter.py
@@ -41,6 +41,8 @@ OSMCHANGE_GENERATOR = f"osmchangewriter (Python {sys.version_info.major}.{sys.ve
 Tag = namedtuple("Tag", "key,value")
 Node = namedtuple("Node", "id, version, lat, lon, tags")
 Way = namedtuple("Way", "id, version, nds, tags")
+Relation = namedtuple("Relation", "id, version, members, tags")
+RelationMember = namedtuple("RelationMember", "ref, type, role")
 
 
 def write_osm_object(osm, writer):
@@ -67,6 +69,13 @@ def write_osm_object(osm, writer):
             if hasattr(osm, "nds"):
                 for nd in osm.nds:
                     writer.write(etree.Element("nd", ref=str(nd)))
+            if hasattr(osm, "members"):
+                for member in osm.members:
+                    writer.write(
+                        etree.Element(
+                            "member", ref=member.ref, type=member.type, role=member.role
+                        )
+                    )
             writer.flush()
     except AttributeError:
         raise RuntimeError(f"OSM Object {osm} is malformed.")

--- a/changegen/generator.py
+++ b/changegen/generator.py
@@ -284,6 +284,12 @@ def _modify_existing_way(way_geom, way_id, nodes, tags, intersection_db):
     ]
 
     for n in add_nodes:
+
+        # ensure at least 2 nodes in linestring
+        if len(way_geom_pts) < 2:
+            logging.warning("Malformed linestring found.")
+            continue
+
         _g = sg.LineString(way_geom_pts)
         idx = _get_point_insertion_index(_g, sg.Point(n.lon, n.lat))
         ip_x, ip_y = way_geom_pts[idx]
@@ -374,7 +380,11 @@ def _generate_ways_and_nodes(
     ]
 
     for n in add_nodes:
-        _tmp_ls = sg.LineString([(_n.lon, _n.lat) for _n in nodes])
+        ls_points = [(_n.lon, _n.lat) for _n in nodes]
+        if len(ls_points) < 2:
+            logging.warning("Malformed linestring found.")
+            continue  # skip linestrings that are not linestrings
+        _tmp_ls = sg.LineString(ls_points)
         idx = _get_point_insertion_index(_tmp_ls, sg.Point(n.lon, n.lat))
         ip_x, ip_y = list(_tmp_ls.coords)[idx]
         # there's a special case here where the intersection point already exists

--- a/changegen/generator.py
+++ b/changegen/generator.py
@@ -597,6 +597,22 @@ def generate_changes(
                         max_nodes_per_way=max_nodes_per_way,
                         closed=True,
                     )
+                    # !! If the exterior Way needs to be split into
+                    # multiple Ways (because it's longer than max_nodes_per_way)
+                    # we need to create a relation in addition to the Ways.
+                    multi_way_relation = None
+                    if len(ways) > 0:
+                        logging.debug(
+                            f"Creating Relation for simple polygon with {len(ways)} members."
+                        )
+                        multi_way_relation = Relation(
+                            id=next(ids),
+                            version=1,
+                            members=[
+                                RelationMember(w.id, "way", "outer") for w in ways
+                            ],
+                            tags=ways[0].tags + [Tag("type", "multipolygon")],
+                        )
                     new_nodes.extend(nodes)
                     new_ways.extend(ways)
                     _global_node_id_all_ways.extend(

--- a/changegen/generator.py
+++ b/changegen/generator.py
@@ -555,7 +555,7 @@ def generate_changes(
             new_nodes.extend(nodes)
             new_ways.extend(ways)
             _global_node_id_all_ways.extend(chain.from_iterable([w.nds for w in ways]))
-        elif isinstance(wgs84_geom, sg.Polygon):
+        if isinstance(wgs84_geom, sg.Polygon):
             # simple polygons can be treated like Ways.
             if len(wgs84_geom.interiors) == 0:
                 ways, nodes = _generate_ways_and_nodes(
@@ -690,13 +690,14 @@ def generate_changes(
                 if isinstance(other_feat_wgs84, sg.Polygon):
                     # Polygons we need to modify the outermost ring of a polygon relation.
                     # However, we need to be sure that the ID that's being referenced here is that of a
-                    # Way and not a Relation.
-                    mod_way = _modify_existing_way(
-                        other_feat_wgs84.exterior,
-                        id,
-                        existing_node_ids,
-                        _feat_tags,
-                        intersection_db,
+                    # Way and not a Relation. This is complicated and likely not worth implementing
+                    # right now.
+                    logging.warning(
+                        (
+                            "Polygon Intersection Warning: a feature intersects "
+                            "With a polygon. Modifying this polygon to add an intersection "
+                            "node is not currently supported."
+                        )
                     )
 
                 modified_ways.append(mod_way)

--- a/changegen/generator.py
+++ b/changegen/generator.py
@@ -37,7 +37,7 @@ def _get_way_node_map(osm, way_idlist):
     class _wayFilter(osmium.SimpleHandler):
         def __init__(self, ids):
             super(_wayFilter, self).__init__()
-            self.ids = ids
+            self.ids = set(ids)
             self.node_map = {}
 
         def way(self, w):

--- a/changegen/generator.py
+++ b/changegen/generator.py
@@ -555,7 +555,7 @@ def generate_changes(
             new_nodes.extend(nodes)
             new_ways.extend(ways)
             _global_node_id_all_ways.extend(chain.from_iterable([w.nds for w in ways]))
-        if isinstance(wgs84_geom, sg.Polygon):
+        elif isinstance(wgs84_geom, sg.Polygon):
             # simple polygons can be treated like Ways.
             if len(wgs84_geom.interiors) == 0:
                 ways, nodes = _generate_ways_and_nodes(

--- a/changegen/util.py
+++ b/changegen/util.py
@@ -14,30 +14,3 @@ def setup_logging(debug=False):
     )
     for name in ["s3transfer", "botocore", "requests.packages.urllib3.connectionpool"]:
         logging.getLogger(name).setLevel(logging.WARNING)
-
-
-class NotRequiredIf(click.Option):
-    def __init__(self, *args, **kwargs):
-        self.not_required_if = kwargs.pop("not_required_if")
-        assert self.not_required_if, "'not_required_if' parameter required"
-        kwargs["help"] = (
-            kwargs.get("help", "")
-            + " NOTE: This argument is mutually exclusive with %s"
-            % self.not_required_if
-        ).strip()
-        super(NotRequiredIf, self).__init__(*args, **kwargs)
-
-    def handle_parse_result(self, ctx, opts, args):
-        we_are_present = self.name in opts
-        other_present = self.not_required_if in opts
-
-        if other_present:
-            if we_are_present:
-                raise click.UsageError(
-                    "Illegal usage: `%s` is mutually exclusive with `%s`"
-                    % (self.name, self.not_required_if)
-                )
-            else:
-                self.prompt = None
-
-        return super(NotRequiredIf, self).handle_parse_result(ctx, opts, args)

--- a/test/test_writer.py
+++ b/test/test_writer.py
@@ -21,6 +21,12 @@ test_objects = [
     changewriter.Way(
         id="-55", version="99", nds=[n.id for n in test_nodes], tags=test_tags
     ),
+    changewriter.Relation(
+        id="-55",
+        version="99",
+        members=[changewriter.RelationMember(ref="255", type="way", role="outer")],
+        tags=test_tags,
+    ),
 ]
 
 
@@ -94,6 +100,31 @@ class TestWriter(unittest.TestCase):
         self.assertTrue(len(parsedElements) == len(objects_to_test))
         self.assertTrue(
             set(parsedElements[0].keys()) == set(["id", "version", "lat", "lon"])
+        )
+        self.assertTrue(len(parsedTags) == len(test_objects[0].tags))
+
+        xmloutput.close()
+        os.remove(xmloutput.name)
+
+    def test_create_relation(self):
+        xmloutput = tempfile.NamedTemporaryFile(delete=False)
+        writer = changewriter.OSMChangeWriter(filename=xmloutput.name)
+        objects_to_test = [test_objects[2]]  # just test relation
+        writer.add_create(objects_to_test)
+        writer.close()
+        _of = open(xmloutput.name, "rb")
+        parsed = etree.parse(_of)
+        _of.close()
+        parsedRoot = parsed.getroot()
+        parsedElements = list(parsedRoot[0])
+        parsedTags = parsed.xpath("/osmChange/create/relation/tag")
+
+        print(etree.tostring(parsed))
+        self.assertTrue(parsedRoot[0].tag == "create")
+        self.assertTrue(parsedElements[0].tag == "relation")
+        self.assertTrue(len(parsedElements) == len(objects_to_test))
+        self.assertTrue(
+            set(parsedElements[0].keys()) == set(["id", "version", "members"])
         )
         self.assertTrue(len(parsedTags) == len(test_objects[0].tags))
 


### PR DESCRIPTION
This PR enables support for features of Polygon type to be exported from a conflation PostGIS database as OSM Closed Ways. Only support for `<create>` nodes was added at this time, though modifications of Polygons might work but probably not and hasn't been tested. 

### Description of Modifications
* add  support for`Relation` and `RelationMember` namedtuples to `changewriter` module 
* add support for detecting Polygon geometry types and creating either `Way` or `Relation` objects to represent them depending on the complexity of the polygon (simple polygons: closed Ways; complex polygons w/ holes: Ways + Relation)
* add support for explicitly closing a `Way` (e.g. appending the first Node in the nodelist of the Way to the end of the Nodelist)
* add support for creating just simple Polygons (e.g. a single closed Way) or more complex polygons (e.g. polygons with holes, which are represented as Relations). 
* make the `--existing/-e` argument optional to disable the search for intersections 
* add a `--max_nodes_per_way` option and allows for `none` as a value.

### Potential Future Work

Because we've stopped ignoring polygon objects, we've opened the possibility that a given _new_ object might intersect with a polygon. Creating `<modify>` nodes to represent changes to existing OSM polygons that intersect with new objects is out of the scope of this PR. This is because it requires tooling to access the ID of a constituent Way that requires modifications, which requires modifications / requirements to the schema in the PostGIS database we're using. 

We've decided to not implement this, and have made an issue for it (#12).