### PR TITLE
Add support for modifying relations based on object metadata

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - doc**
+      - **doc**
 
 jobs:
   deploy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,10 @@
 name: Build Sphinx to Github Pages
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
-      - **doc**
 
 jobs:
   deploy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,3 +44,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_build/html/
+          enable_jekyll: false

--- a/changegen/__main__.py
+++ b/changegen/__main__.py
@@ -147,6 +147,27 @@ def _get_db_tables(suffix, dbname, dbport, dbuser, dbpass, dbhost):
     ),
     default="2000",
 )
+@click.option(
+    "--modify_relations",
+    is_flag=True,
+    help=(
+        "Add new objects to parent relations specified by a special tag.  "
+        'The default tag prefix for tags containing Relation IDs is "_member_of_". '
+        "Pass the --relation_member_prefix flag to change "
+        "this prefix, e.g. --relation_member_prefix __a_different_prefix_. "
+        "See changegen.relations.py for more information. "
+    ),
+)
+@click.option(
+    "--relation_member_prefix",
+    is_flag=False,
+    help=(
+        "Only used with --modify_relations. Specify the tag prefix "
+        "used to search for IDs to to add new OSM objects to."
+    ),
+    default="_member_of_",
+    show_default=True,
+)
 @click.option("--osmsrc", help="Source OSM PBF File path", required=True)
 @click.argument("dbname", default=os.environ.get("PGDATABASE", "conflate"))
 @click.argument("dbport", default=os.environ.get("PGPORT", "15432"))
@@ -233,6 +254,8 @@ def main(*args: tuple, **kwargs: dict):
             self_intersections=kwargs["self"],
             max_nodes_per_way=int(max_nodes_per_way),
             modify_only=kwargs["modify_meta"],
+            modify_relations=kwargs["modify_relations"],
+            relation_member_prefix=kwargs["relation_member_prefix"],
         )
 
     for table in kwargs["deletions"]:

--- a/changegen/__main__.py
+++ b/changegen/__main__.py
@@ -152,20 +152,20 @@ def _get_db_tables(suffix, dbname, dbport, dbuser, dbpass, dbhost):
     is_flag=True,
     help=(
         "Add new objects to parent relations specified by a special tag.  "
-        'The default tag prefix for tags containing Relation IDs is "_member_of_". '
-        "Pass the --relation_member_prefix flag to change "
-        "this prefix, e.g. --relation_member_prefix __a_different_prefix_. "
+        'The default tag prefix for tags containing Relation IDs is "_member_of". '
+        "Pass the --relation_tag flag to change "
+        "this prefix, e.g. --relation_tag __a_different_prefix_. "
         "See changegen.relations.py for more information. "
     ),
 )
 @click.option(
-    "--relation_member_prefix",
+    "--relation_tag",
     is_flag=False,
     help=(
         "Only used with --modify_relations. Specify the tag prefix "
         "used to search for IDs to to add new OSM objects to."
     ),
-    default="_member_of_",
+    default="_member_of",
     show_default=True,
 )
 @click.option("--osmsrc", help="Source OSM PBF File path", required=True)
@@ -255,7 +255,7 @@ def main(*args: tuple, **kwargs: dict):
             max_nodes_per_way=int(max_nodes_per_way),
             modify_only=kwargs["modify_meta"],
             modify_relations=kwargs["modify_relations"],
-            relation_member_prefix=kwargs["relation_member_prefix"],
+            relation_tag=kwargs["relation_tag"],
         )
 
     for table in kwargs["deletions"]:

--- a/changegen/changewriter.py
+++ b/changegen/changewriter.py
@@ -107,7 +107,7 @@ class OSMChangeWriter(object):
     )
     _root_element_close = "</osmChange>"
 
-    def __init__(self, filename=None, compress=False):
+    def __init__(self, filename=None, compress=False, keepcopy=False):
         super(OSMChangeWriter, self).__init__()
 
         self.compress = compress
@@ -115,6 +115,10 @@ class OSMChangeWriter(object):
         self.fileobj = None
         self.closed = False
         self._data_written = False
+        self.keepcopy = keepcopy
+        self.created = []
+        self.modified = []
+        self.deleted = []
 
         # set fileobj based on compression
         if self.filename and self.compress:
@@ -163,6 +167,8 @@ class OSMChangeWriter(object):
                     write_osm_object(e, writer)
             writer.flush()
         self._data_written = True
+        if self.keepcopy:
+            self.modified.extend(elementlist)
 
     def add_create(self, elementlist):
         """Creates <create> element containing
@@ -178,6 +184,8 @@ class OSMChangeWriter(object):
                     write_osm_object(e, writer)
             writer.flush()
         self._data_written = True
+        if self.keepcopy:
+            self.created.extend(elementlist)
 
     def add_delete(self, elementlist):
         """Creates a <delete> element containing
@@ -189,3 +197,5 @@ class OSMChangeWriter(object):
                     write_osm_object(e, writer)
                 writer.flush()
         self._data_written = True
+        if self.keepcopy:
+            self.deleted.extend(elementlist)

--- a/changegen/generator.py
+++ b/changegen/generator.py
@@ -683,7 +683,7 @@ def generate_changes(
 
         ## Relation Updates: If modify_relations is true,
         ## we'll search through all newly-added objects
-        ## for Tags with the "relation_member" prefix
+        ## for Tags with prefix specified by `relation_member_prefix`
         ## and add them to the relations specified by the
         ## values of those tags.
         modified_relations = []

--- a/changegen/generator.py
+++ b/changegen/generator.py
@@ -485,7 +485,7 @@ def generate_changes(
     max_nodes_per_way=2000,
     modify_only=False,
     modify_relations=False,
-    relation_member_prefix="_member_of",
+    relation_tag="_member_of",
 ):
     """
     Generate an osm changefile (outfile) based on features in <table>
@@ -709,7 +709,7 @@ def generate_changes(
 
     ## Relation Updates: If modify_relations is true,
     ## we'll search through all newly-added objects
-    ## for Tags with prefix specified by `relation_member_prefix`
+    ## for Tags with prefix specified by `relation_tag`
     ## and add them to the relations specified by the
     ## values of those tags.
     modified_relations = []
@@ -718,11 +718,13 @@ def generate_changes(
         relations_mentioned = set()
         for obj in change_writer.created:
             relations_mentioned.update(
-                [
-                    _t.value
-                    for _t in obj.tags
-                    if _t.key.startswith(relation_member_prefix)
-                ]
+                chain.from_iterable(
+                    [
+                        _t.value.split(",")
+                        for _t in obj.tags
+                        if _t.key.startswith(relation_tag)
+                    ]
+                )
             )
         # create relations DB
         updater.get_relations(relations_mentioned, osmsrc)
@@ -731,7 +733,7 @@ def generate_changes(
             change_writer.created,
             desc="Checking objects for relations...",
         ):
-            updater.modify_relations_with_object(obj, relation_member_prefix)
+            updater.modify_relations_with_object(obj, relation_tag)
         # get modified relations
         modified_relations = updater.get_modified_relations()
         ## Write modified relations too.

--- a/changegen/generator.py
+++ b/changegen/generator.py
@@ -486,6 +486,7 @@ def generate_changes(
     modify_only=False,
     modify_relations=False,
     relation_tag="_member_of",
+    relation_insertion_tag="parent_osm_id",
 ):
     """
     Generate an osm changefile (outfile) based on features in <table>
@@ -733,7 +734,21 @@ def generate_changes(
             change_writer.created,
             desc="Checking objects for relations...",
         ):
-            updater.modify_relations_with_object(obj, relation_tag)
+            # check to see if a tag that matches `relation_insertion_tag`
+            # is present, and if so, provide the value as`
+            # at_id to insert the new object at the location of that
+            # ID in the relation.
+            at_id = None
+            try:
+                at_id = [
+                    t.value
+                    for t in obj.tags
+                    if t.key.startswith(relation_insertion_tag)
+                ][0]
+            except IndexError:
+                # did not find insertion tag. at_id is none.
+                at_id = None
+            updater.modify_relations_with_object(obj, relation_tag, at_id)
         # get modified relations
         modified_relations = updater.get_modified_relations()
         ## Write modified relations too.

--- a/changegen/generator.py
+++ b/changegen/generator.py
@@ -24,9 +24,7 @@ from .changewriter import RelationMember
 from .changewriter import Tag
 from .changewriter import Way
 from .db import OGRDBReader
-from .relations import get_modified_relations
-from .relations import get_relations
-from .relations import modify_relations_with_object
+from .relations import RelationUpdater
 
 WGS84 = pyproj.CRS("EPSG:4326")
 WEBMERC = pyproj.CRS("EPSG:3857")
@@ -712,6 +710,7 @@ def generate_changes(
     ## values of those tags.
     modified_relations = []
     if modify_relations:
+        updater = RelationUpdater()
         relations_mentioned = set()
         for obj in chain(new_ways, new_nodes, new_relations):
             relations_mentioned.update(
@@ -722,15 +721,15 @@ def generate_changes(
                 ]
             )
         # create relations DB
-        get_relations(relations_mentioned, osmsrc)
+        updater.get_relations(relations_mentioned, osmsrc)
         # update db for each new object
         for obj in tqdm(
             new_ways + new_nodes + new_relations,
             desc="Checking objects for relations...",
         ):
-            modify_relations_with_object(obj, relation_member_prefix)
+            updater.modify_relations_with_object(obj, relation_member_prefix)
         # get modified relations
-        modified_relations = get_modified_relations()
+        modified_relations = updater.get_modified_relations()
         ## Write modified relations too.
         if len(modified_relations) > 0:
             change_writer.add_modify(modified_relations)

--- a/changegen/relations.py
+++ b/changegen/relations.py
@@ -126,7 +126,6 @@ class RelationUpdater(object):
             for tag in osm_object.tags
             if tag.key.startswith(relation_tag_prefix)
         ]
-
         # update each relation with osm_object.
         for relation in relation_ids:
             existing_relation = None

--- a/changegen/relations.py
+++ b/changegen/relations.py
@@ -145,9 +145,9 @@ def modify_relations_with_object(
         # create a new RelationMember containing the new object
         objectMember = RelationMember(
             ref=osm_object.id,
-            type=type(osm_object)
-            .__name__[0]
-            .lower(),  # Node --> 'n', Way --> 'w', 'Relation' -> 'r',
+            type=type(
+                osm_object
+            ).__name__.lower(),  # Node --> 'node', Way --> 'way', 'Relation' -> 'relation',
             role="",
         )
 

--- a/changegen/relations.py
+++ b/changegen/relations.py
@@ -86,6 +86,9 @@ def modify_relations_with_object(
     we add a RelationMember to the relation representing `osm_object`
     and update the database.
 
+    This function is not a "pure" function -- it modifies underlying state
+    without returning anything.
+
     Relations that are not found in RELATIONS_DB are skipped.
 
     NOTE that this function does not support Roles.
@@ -96,8 +99,7 @@ def modify_relations_with_object(
     for all Relations that are referred-to by Tags in the OSM objects to be
     inserted.
 
-    NOTE that this function, in addition to returning modified Relations,
-    also modifies the underlying relation
+
 
     """
 
@@ -140,6 +142,7 @@ def modify_relations_with_object(
             )
             continue
 
+        # create a new RelationMember containing the new object
         objectMember = RelationMember(
             ref=osm_object.id,
             type=type(osm_object)
@@ -148,6 +151,7 @@ def modify_relations_with_object(
             role="",
         )
 
+        # create a new relation containing the new member.
         new_relation = Relation(
             id=existing_relation.id,
             version=existing_relation.version,
@@ -163,11 +167,9 @@ def modify_relations_with_object(
 
 def get_relations(ids: List[str], osm_filepath: str) -> Dict[str, Relation]:
     """
-    Creates a global a mapping of OSM IDs to Relation objects for each relation
+    Creates an internal mapping of OSM IDs to Relation objects for each relation
     in the OSM file that's specified by `osm_filepath`
     that is specified in `ids`.
-
-    This function also sets the global variable `RELATIONS_DB`.
 
     """
 

--- a/changegen/relations.py
+++ b/changegen/relations.py
@@ -12,6 +12,9 @@ from .changewriter import RelationMember
 from .changewriter import Tag
 from .changewriter import Way
 
+# whether to use "way" or "w" (etc) for
+# the "type" field of RelationMembers.
+LONG_RELATION_MEMBER_TYPE = True
 
 """
 
@@ -143,11 +146,12 @@ def modify_relations_with_object(
             continue
 
         # create a new RelationMember containing the new object
+        rm_type = type(osm_object).__name__.lower()
+        if not LONG_RELATION_MEMBER_TYPE:
+            rm_type = rm_type[0]
         objectMember = RelationMember(
             ref=osm_object.id,
-            type=type(
-                osm_object
-            ).__name__.lower(),  # Node --> 'node', Way --> 'way', 'Relation' -> 'relation',
+            type=rm_type,
             role="",
         )
 
@@ -189,8 +193,15 @@ def get_relations(ids: List[str], osm_filepath: str) -> Dict[str, Relation]:
         ) -> List[RelationMember]:
             memberList: List[RelationMember] = []
             for member in members:
+                _type = member.type
+                if LONG_RELATION_MEMBER_TYPE:
+                    _type = {
+                        "w": "way",
+                        "n": "node",
+                        "r": "relation",
+                    }[member.type]
                 memberList.append(
-                    RelationMember(ref=member.ref, type=member.type, role=member.role)
+                    RelationMember(ref=member.ref, type=_type, role=member.role)
                 )
             return memberList
 

--- a/changegen/relations.py
+++ b/changegen/relations.py
@@ -1,0 +1,214 @@
+import logging
+from typing import Dict
+from typing import List
+from typing import Set
+from typing import Union
+
+import osmium
+
+from .changewriter import Node
+from .changewriter import Relation
+from .changewriter import RelationMember
+from .changewriter import Tag
+from .changewriter import Way
+
+
+"""
+
+Relation Management
+====================
+
+This module provides support for modifying Relations. It supports a few use-cases. 
+
+1. A <create> tag will be created, and some objects within it need to be 
+   added to relations that already exist. In this case, <modify> tags are 
+   created that modify the Relations in question. 
+2. more later probably
+
+It is important to note that this module is STATEFUL. It should probably be a class. 
+If you need to clear the relations DB and modified relations list, you can use _reset().
+
+Insertion in to Existing Relations
+-----------------------------------
+
+In order to insert an object into an existing relation a particular schema 
+of the input data is required. In particular, any object that is to be inserted
+into a Relation must contain a Tag with a Key that begins with a user-specifiable 
+prefix and a Value that represents the ID of the Relation that the object should be
+inserted into. 
+
+The default Tag Key that is used is `_member_of`. (To use another, pass it as
+the `relation_tag_prefix` argument to `get_modified_relations_for_object`). 
+
+`modify_relations_with_object` is responsible for modifying a local
+database of Relations with by objects to them, as specified in the object itself. 
+
+Before running `modify_relations_with_object`, a local database of
+Relations must be generated. This is done by providing a list of 
+Relation IDs to `get_relations`. This is an expensive operation, 
+so should be done as infrequently as possible (likely just once).
+
+The list of IDs provided to `get_relations` should represent all relations
+that need to be inserted into. 
+
+After processing objects is complete, call get_modified_relations 
+to obtain a list of modified relations that can then be used to create
+<modify> tags in a changefile. 
+
+"""
+
+RELATIONS_DB: Dict[str, Relation] = {}
+MODIFIED_RELATIONS: Set[str] = set()
+
+
+def _reset():
+    # Used for tests currently.
+    global RELATIONS_DB
+    global MODIFIED_RELATIONS
+
+    RELATIONS_DB = {}
+    MODIFIED_RELATIONS = set()
+
+
+def get_modified_relations():
+    return [RELATIONS_DB[_r] for _r in MODIFIED_RELATIONS]
+
+
+def modify_relations_with_object(
+    osm_object: Union[Relation, Node, Way], relation_tag_prefix: str = "_member_of_"
+) -> List[Relation]:
+    """
+
+    This function interrogates `osm_object` for Tags whose
+    keys begin with `relation_tag_prefix`. For all keys that begin with
+    that prefix, the function searches a database of relations using the values
+    of those tags as the relation ID. For all matching relations
+    we add a RelationMember to the relation representing `osm_object`
+    and update the database.
+
+    Relations that are not found in RELATIONS_DB are skipped.
+
+    NOTE that this function does not support Roles.
+
+    NOTE that this function requires that `get_relations` is invoked
+    first. We need to read data from the OSM file only once. You must ensure
+    that the invocation of `get_relations` obtains Relation objects
+    for all Relations that are referred-to by Tags in the OSM objects to be
+    inserted.
+
+    NOTE that this function, in addition to returning modified Relations,
+    also modifies the underlying relation
+
+    """
+
+    # these are global because we need to update them
+    # with additions to Relations. Seperate
+    # invocations need access to the updates, so it
+    # has to be global. I don't love it but
+    # I think that's easier than having
+    # clients maintain state themselves?
+    global RELATIONS_DB
+    global MODIFIED_RELATIONS
+
+    relations_in_db = 0
+    try:
+        relations_in_db = len(RELATIONS_DB.keys())
+    except NameError:
+        raise Exception("No Relations Database exists. Did you run get_relations?")
+
+    if relations_in_db == 0:
+        raise RuntimeWarning(
+            (
+                "There are no relations in the relations database. "
+                "No objects will be added to any relations. "
+            )
+        )
+
+    # search for matching tags that represent relation IDs
+    relation_ids = [
+        tag.value for tag in osm_object.tags if tag.key.startswith(relation_tag_prefix)
+    ]
+
+    # update each relation with osm_object.
+    for relation in relation_ids:
+        existing_relation = None
+        try:
+            existing_relation = RELATIONS_DB[relation]
+        except KeyError:
+            logging.debug(
+                f"Skipping modifying relation {relation} with object {osm_object.id} because it does not exist in database."
+            )
+            continue
+
+        objectMember = RelationMember(
+            ref=osm_object.id,
+            type=type(osm_object)
+            .__name__[0]
+            .lower(),  # Node --> 'n', Way --> 'w', 'Relation' -> 'r',
+            role="",
+        )
+
+        new_relation = Relation(
+            id=existing_relation.id,
+            version=existing_relation.version,
+            members=existing_relation.members + [objectMember],
+            tags=existing_relation.tags,
+        )
+
+        # update relations DB
+        RELATIONS_DB[relation] = new_relation
+        # add modified relation to set of modified relations
+        MODIFIED_RELATIONS.add(relation)
+
+
+def get_relations(ids: List[str], osm_filepath: str) -> Dict[str, Relation]:
+    """
+    Creates a global a mapping of OSM IDs to Relation objects for each relation
+    in the OSM file that's specified by `osm_filepath`
+    that is specified in `ids`.
+
+    This function also sets the global variable `RELATIONS_DB`.
+
+    """
+
+    # we need to update the module-level
+    # variable here, so we ensure that we're
+    # using global scope for this variable.
+    global RELATIONS_DB
+
+    class _RelationReader(osmium.SimpleHandler):
+        def __init__(self, ids):
+            super(_RelationReader, self).__init__()
+            self.ids = set(ids)
+            self.relations: Dict[str, Relation] = {}
+
+        def _convert_members(
+            self, members: osmium.osm.RelationMemberList
+        ) -> List[RelationMember]:
+            memberList: List[RelationMember] = []
+            for member in members:
+                memberList.append(
+                    RelationMember(ref=member.ref, type=member.type, role=member.role)
+                )
+            return memberList
+
+        def _convert_tags(self, tags: osmium.osm.TagList) -> List[Tag]:
+            tagList: List[Tag] = []
+            for tag in tags:
+                tagList.append(Tag(key=tag.k, value=tag.v))
+            return tagList
+
+        def relation(self, r):
+            if str(r.id) in self.ids:
+                self.relations[str(r.id)] = Relation(
+                    id=str(r.id),
+                    version=2,
+                    members=self._convert_members(r.members),
+                    tags=self._convert_tags(r.tags),
+                )
+
+    _reader = _RelationReader(ids)
+    _reader.apply_file(osm_filepath)
+
+    # set the global variable
+    RELATIONS_DB = _reader.relations

--- a/changegen/relations.py
+++ b/changegen/relations.py
@@ -199,7 +199,7 @@ class RelationUpdater(object):
                 return tagList
 
             def relation(__self, r):
-                if str(r.id) in self.ids:
+                if str(r.id) in __self.ids:
                     __self.relations[str(r.id)] = Relation(
                         id=str(r.id),
                         version=2,

--- a/test/test_relations.py
+++ b/test/test_relations.py
@@ -22,6 +22,14 @@ test_insertion_object = changewriter.Node(
     tags=[changewriter.Tag(key="_member_of_somerelation", value=test_relation_id)],
 )
 
+another_test_insertion_object = changewriter.Node(
+    id="9998",
+    version="-1",
+    lat="0",
+    lon="0",
+    tags=[changewriter.Tag(key="_member_of_somerelation", value=test_relation_id)],
+)
+
 test_insertion_object_missing_relation = changewriter.Node(
     id="9999",
     version="-1",
@@ -34,27 +42,39 @@ test_insertion_object_missing_relation = changewriter.Node(
 class TestRelations(unittest.TestCase):
     def test_add_node_to_relation(self):
         """Ensure that a Node gets added to a Relation properly."""
-        relations._reset()
+        ru = relations.RelationUpdater()
         ## we need to cheat and patch RELATIONS_DB with our mock
         ## because I don't want to test get_relations here.
-        relations.RELATIONS_DB = test_relation_db
+        ru.RELATIONS_DB = test_relation_db
 
-        relations.modify_relations_with_object(test_insertion_object)
+        ru.modify_relations_with_object(test_insertion_object)
 
-        modified_relations = relations.get_modified_relations()
+        modified_relations = ru.get_modified_relations()
 
         self.assertEqual(len(modified_relations), 1)
 
+    def test_add_multiple(self):
+        """Ensure that adding multiple ways to relation works."""
+        ru = relations.RelationUpdater()
+        ru.RELATIONS_DB = test_relation_db
+
+        ru.modify_relations_with_object(test_insertion_object)
+        ru.modify_relations_with_object(another_test_insertion_object)
+
+        modified_relations = ru.get_modified_relations()
+
+        self.assertEqual(len(modified_relations[0].members), 3)
+
     def test_proper_relation_member_formatting(self):
         """Ensure that the RelationMember that's added to the Relation is proper"""
-        relations._reset()
+        ru = relations.RelationUpdater()
         ## we need to cheat and patch RELATIONS_DB with our mock
         ## because I don't want to test get_relations here.
-        relations.RELATIONS_DB = test_relation_db
+        ru.RELATIONS_DB = test_relation_db
 
-        relations.modify_relations_with_object(test_insertion_object)
+        ru.modify_relations_with_object(test_insertion_object)
 
-        modified_relations = relations.get_modified_relations()
+        modified_relations = ru.get_modified_relations()
 
         self.assertTrue(modified_relations[0].members[1].type == "node")
         self.assertTrue(
@@ -63,12 +83,12 @@ class TestRelations(unittest.TestCase):
         self.assertTrue(modified_relations[0].members[1].role == "")
 
     def test_relation_missing(self):
-        relations._reset()
+        ru = relations.RelationUpdater()
 
-        relations.RELATIONS_DB = test_relation_db
+        ru.RELATIONS_DB = test_relation_db
 
-        relations.modify_relations_with_object(test_insertion_object_missing_relation)
+        ru.modify_relations_with_object(test_insertion_object_missing_relation)
 
-        modified_relations = relations.get_modified_relations()
+        modified_relations = ru.get_modified_relations()
 
         self.assertEqual(len(modified_relations), 0)

--- a/test/test_relations.py
+++ b/test/test_relations.py
@@ -1,0 +1,74 @@
+import unittest
+
+from changegen import changewriter
+from changegen import relations
+
+test_relation_id = "4567"
+
+test_relation_db = {
+    test_relation_id: changewriter.Relation(
+        id=test_relation_id,
+        version="-1",
+        members=[changewriter.RelationMember("-1", type="w", role="")],
+        tags=changewriter.Tag(key="tagkey", value="tagvalue"),
+    )
+}
+
+test_insertion_object = changewriter.Node(
+    id="9999",
+    version="-1",
+    lat="0",
+    lon="0",
+    tags=[changewriter.Tag(key="_member_of_somerelation", value=test_relation_id)],
+)
+
+test_insertion_object_missing_relation = changewriter.Node(
+    id="9999",
+    version="-1",
+    lat="0",
+    lon="0",
+    tags=[changewriter.Tag(key="_member_of_somerelation", value="-1")],
+)
+
+
+class TestRelations(unittest.TestCase):
+    def test_add_node_to_relation(self):
+        """Ensure that a Node gets added to a Relation properly."""
+        relations._reset()
+        ## we need to cheat and patch RELATIONS_DB with our mock
+        ## because I don't want to test get_relations here.
+        relations.RELATIONS_DB = test_relation_db
+
+        relations.modify_relations_with_object(test_insertion_object)
+
+        modified_relations = relations.get_modified_relations()
+
+        self.assertEqual(len(modified_relations), 1)
+
+    def test_proper_relation_member_formatting(self):
+        """Ensure that the RelationMember that's added to the Relation is proper"""
+        relations._reset()
+        ## we need to cheat and patch RELATIONS_DB with our mock
+        ## because I don't want to test get_relations here.
+        relations.RELATIONS_DB = test_relation_db
+
+        relations.modify_relations_with_object(test_insertion_object)
+
+        modified_relations = relations.get_modified_relations()
+
+        self.assertTrue(modified_relations[0].members[1].type == "n")
+        self.assertTrue(
+            modified_relations[0].members[1].ref == test_insertion_object.id
+        )
+        self.assertTrue(modified_relations[0].members[1].role == "")
+
+    def test_relation_missing(self):
+        relations._reset()
+
+        relations.RELATIONS_DB = test_relation_db
+
+        relations.modify_relations_with_object(test_insertion_object_missing_relation)
+
+        modified_relations = relations.get_modified_relations()
+
+        self.assertEqual(len(modified_relations), 0)

--- a/test/test_relations.py
+++ b/test/test_relations.py
@@ -9,7 +9,7 @@ test_relation_db = {
     test_relation_id: changewriter.Relation(
         id=test_relation_id,
         version="-1",
-        members=[changewriter.RelationMember("-1", type="w", role="")],
+        members=[changewriter.RelationMember("-1", type="way", role="")],
         tags=changewriter.Tag(key="tagkey", value="tagvalue"),
     )
 }
@@ -56,7 +56,7 @@ class TestRelations(unittest.TestCase):
 
         modified_relations = relations.get_modified_relations()
 
-        self.assertTrue(modified_relations[0].members[1].type == "n")
+        self.assertTrue(modified_relations[0].members[1].type == "node")
         self.assertTrue(
             modified_relations[0].members[1].ref == test_insertion_object.id
         )


### PR DESCRIPTION
Adding activity classification to the pre-import pipeline (https://github.com/trailbehind/USFSConflation/pull/32) has revealed that we will sometimes need to ensure that new OSM objects added during conflation are also added to relations. 

This PR implements the ability to include newly-created OSM  objects into existing Relations. We do this by looking for a special Tag name prefix (currently `_member_of_`). These tags should contain as their Values the ID of a relation that the objects should be added to. 

After creating a mapping from ID -> Relation, we lookup the relations referenced in the `_member_of` Tags and add the OSM object that has that tag to the corresponding relation in the aforementioned mapping. We also keep track of the modified relations. 

Once all objects are processed, we output a list of modified Relation objects and create a `<modify>` tag for them in the changefile. 

This feature is disabled by default and can be enabled with the `--modify_relations` flag. 

I haven't tested this fully yet.