### PR TITLE
Enable support for `hstore` columns containing tags.

### DIFF
--- a/changegen/__main__.py
+++ b/changegen/__main__.py
@@ -147,6 +147,18 @@ def _get_db_tables(suffix, dbname, dbport, dbuser, dbpass, dbhost):
     ),
     default="2000",
 )
+@click.option(
+    "--hstore_tags",
+    help=(
+        "Specify Postgres hstore column to obtain tags from, "
+        "in addition to table columns. "
+        "This column should contain a hstore, and the keys will be compared "
+        "to existing columns. Column key values will take "
+        "precedence over values in the hstore if duplicates are found."
+    ),
+    default=None,
+    show_default=True,
+)
 @click.option("--osmsrc", help="Source OSM PBF File path", required=True)
 @click.argument("dbname", default=os.environ.get("PGDATABASE", "conflate"))
 @click.argument("dbport", default=os.environ.get("PGPORT", "15432"))
@@ -233,6 +245,7 @@ def main(*args: tuple, **kwargs: dict):
             self_intersections=kwargs["self"],
             max_nodes_per_way=int(max_nodes_per_way),
             modify_only=kwargs["modify_meta"],
+            hstore_column=kwargs["hstore_tags"],
         )
 
     for table in kwargs["deletions"]:

--- a/changegen/__main__.py
+++ b/changegen/__main__.py
@@ -154,7 +154,9 @@ def _get_db_tables(suffix, dbname, dbport, dbuser, dbpass, dbhost):
         "in addition to table columns. "
         "This column should contain a hstore, and the keys will be compared "
         "to existing columns. Column key values will take "
-        "precedence over values in the hstore if duplicates are found."
+        "precedence over values in the hstore if duplicates are found. "
+        "Note that this column name will apply to both source tables "
+        "and intersection tables. "
     ),
     default=None,
     show_default=True,

--- a/changegen/db.py
+++ b/changegen/db.py
@@ -14,12 +14,15 @@ def hstore_as_dict(hstore_str):
     :type hstore_str: str
     :rtype: dict
     """
-    return dict(
-        map(
-            lambda x: map(lambda x: x.strip(), x.split("=>")),
-            hstore_str.replace('"', "").split(","),
+    if len(hstore_str) > 0:
+        return dict(
+            map(
+                lambda x: map(lambda x: x.strip().replace('"', ""), x.split("=>")),
+                hstore_str.split('", '),
+            )
         )
-    )
+    else:
+        return {}
 
 
 class OGRDBReader(object):

--- a/changegen/db.py
+++ b/changegen/db.py
@@ -4,6 +4,24 @@ import warnings
 from osgeo import ogr
 
 
+def hstore_as_dict(hstore_str):
+    """
+    Converts a string representation of a Postgres hstore
+    into a Python dictionary. hstore strings should be
+    of the form "'key1'=>'value1', "key2"=>"value2", ..."
+
+    :param hstore_str: hstore string
+    :type hstore_str: str
+    :rtype: dict
+    """
+    return dict(
+        map(
+            lambda x: map(lambda x: x.strip(), x.split("=>")),
+            hstore_str.replace('"', "").split(","),
+        )
+    )
+
+
 class OGRDBReader(object):
     """Read features from PostGIS database via OGR."""
 

--- a/changegen/generator.py
+++ b/changegen/generator.py
@@ -185,12 +185,18 @@ def _generate_tags_from_feature(feature, fields, hstore_column=None, exclude=[])
     # seen from <fields> as Tags to the `tags` list
     if hstore_column:
         existing_keys = set(fields)
-        hstore_content = hstore_as_dict(
-            feature.GetFieldAsString(feature.GetFieldIndex(hstore_column))
-        )
-        logging.debug(
-            f'Found {len(hstore_content.keys())} keys in hstore column "{hstore_column}" for feature {feature.GetFID()}'
-        )
+        hstore_content = {}
+        try:
+            hstore_content = hstore_as_dict(
+                feature.GetFieldAsString(feature.GetFieldIndex(hstore_column))
+            )
+            logging.debug(
+                f'Found {len(hstore_content.keys())} keys in hstore column "{hstore_column}" for feature {feature.GetFID()}'
+            )
+        except ValueError:
+            logging.error(
+                '!! Error parsing hstore column "{hstore_column}" for feature {feature.GetFID()}.'
+            )
         for key, value in hstore_content.items():
             if key not in existing_keys:
                 tags.append(Tag(key=key, value=value))

--- a/changegen/generator.py
+++ b/changegen/generator.py
@@ -483,6 +483,7 @@ def generate_changes(
     self_intersections=False,
     max_nodes_per_way=2000,
     modify_only=False,
+    hstore_column=None,
 ):
     """
     Generate an osm changefile (outfile) based on features in <table>

--- a/changegen/generator.py
+++ b/changegen/generator.py
@@ -195,8 +195,6 @@ def _generate_tags_from_feature(feature, fields, hstore_column=None, exclude=[])
             if key not in existing_keys:
                 tags.append(Tag(key=key, value=value))
 
-    # split hstore string ("key"=>"value", "key2"=>"value2", ...) into json(?) or dict
-
     return tags
 
 

--- a/changegen/generator.py
+++ b/changegen/generator.py
@@ -175,6 +175,10 @@ def _generate_tags_from_feature(feature, fields, hstore_column=None, exclude=[])
     are ignored, and columns take precedence.)
     """
     tags = []
+    # if hstore column is present, we don't want to include
+    # it in the output set of tags:
+    if hstore_column:
+        exclude.append(hstore_column)
     for field in fields:
         if field in exclude:
             continue  # skip

--- a/changegen/generator.py
+++ b/changegen/generator.py
@@ -170,7 +170,9 @@ def _generate_tags_from_feature(feature, fields, hstore_column=None, exclude=[])
     """returns list of tags given layer fields and a feature containing
     fields. Will not produce a tag for any field name in <exclude>.
 
-    If hstore_column is not null,
+    If hstore_column is not null, tags will also be derived from the hstore column.
+    Only tags that are _not_ present in <fields> will be added as Tags (duplicates
+    are ignored, and columns take precedence.)
     """
     tags = []
     for field in fields:

--- a/changegen/generator.py
+++ b/changegen/generator.py
@@ -190,9 +190,6 @@ def _generate_tags_from_feature(feature, fields, hstore_column=None, exclude=[])
             hstore_content = hstore_as_dict(
                 feature.GetFieldAsString(feature.GetFieldIndex(hstore_column))
             )
-            logging.debug(
-                f'Found {len(hstore_content.keys())} keys in hstore column "{hstore_column}" for feature {feature.GetFID()}'
-            )
         except ValueError:
             logging.error(
                 '!! Error parsing hstore column "{hstore_column}" for feature {feature.GetFID()}.'


### PR DESCRIPTION
This PR enables the use of Postgres hstore columns as a source of key:value pairs to be used to generate Tags for a given new or modified PostGIS feature. This is primarily to support the `imposm` [`hstore_tags`](https://imposm.org/docs/imposm3/latest/mapping.html#hstore-tags) feature. This is useful when a conflation only requires a subset of tags, but the output planet file must also contain all tags present in the source data. More details: https://github.com/trailbehind/changegen/issues/18


Closes #18 on top of #17 