### PR TITLE
Revise modification of existing Ways' threshold for insertion of intersection nodes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.2.0
     hooks:
       - id: end-of-file-fixer
       - id: check-json
@@ -9,18 +9,18 @@ repos:
       - id: check-merge-conflict
       - id: no-commit-to-branch
         args: [--branch, master]
-  - repo: https://github.com/ambv/black
-    rev: 20.8b1
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.3.5
+    rev: v3.1.0
     hooks:
       - id: reorder-python-imports
         language_version: python3
-  - repo: https://github.com/prettier/prettier
-    rev: 2.1.2
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.6.2
     hooks:
       - id: prettier
         language_version: system

--- a/changegen/generator.py
+++ b/changegen/generator.py
@@ -328,7 +328,7 @@ def _modify_existing_way(way_geom, way_id, nodes, tags, intersection_db):
                 way_geom.buffer(0.01).bounds, objects=True
             )
         ]
-        if way_geom.intersects(sg.Point(n.lon, n.lat).buffer(0.0005))
+        if way_geom.intersects(sg.Point(n.lon, n.lat).buffer(0.0001))
     ]
 
     for n in add_nodes:


### PR DESCRIPTION
Existing ways are modified to include nodes that represent intersections with newly-created Ways. The threshold that was being used to determine whether an intersection node should be added to an existing Way previously was too high. This caused intersection nodes to be added to existing ways when they shouldn't have been, which created all kinds of chaos in situations where roads are close together or roughly parallel. 

This PR modifies the threshold used to determine whether a node should be added to an existing Way. 

I chose 0.0001 (to replace 0.0005) because (at ~11m) it's roughly double the threshold used to determine intersections (5m). Perhaps a more conservative choice would be 0.00005 (0.0001 / 2), but I wanted to give some wiggle room still because we do coordinate transformations. 

I tested this on a recent conflation and the artifacts I set out to fix were improved, so I figure this is a good change in threshold. 

(This PR also contains pre-commit updates because it was broken).