### PR TITLE
Make intersection matching buffer on existing roads _even_ smaller.

### DIFF
--- a/changegen/generator.py
+++ b/changegen/generator.py
@@ -317,7 +317,7 @@ def _modify_existing_way(way_geom, way_id, nodes, tags, intersection_db):
     way_geom_pts = list(way_geom.coords)
     if len(way_geom_pts) > WAY_POINT_THRESHOLD:
         logging.warning(
-            f"There are {len(way_geom_pts)} in the linestring, which is greater than the threshold ({WAY_POINT_THRESHOLD})."
+            f"There are {len(way_geom_pts)} in the linestring (way_id: {way_id}), which is greater than the threshold ({WAY_POINT_THRESHOLD})."
         )
 
     add_nodes = [
@@ -328,7 +328,7 @@ def _modify_existing_way(way_geom, way_id, nodes, tags, intersection_db):
                 way_geom.buffer(0.01).bounds, objects=True
             )
         ]
-        if way_geom.intersects(sg.Point(n.lon, n.lat).buffer(0.0001))
+        if way_geom.intersects(sg.Point(n.lon, n.lat).buffer(0.00005))
     ]
 
     for n in add_nodes:


### PR DESCRIPTION
When I did this the first time (#25) I noted the following about the choice of threshold (in degrees):
> _I chose 0.0001 (to replace 0.0005) because (at ~11m) it's roughly double the threshold used to determine intersections (5m). Perhaps a more conservative choice would be 0.00005 (0.0001 / 2), but I wanted to give some wiggle room still because we do coordinate transformations._

I made the "more conservative choice" with this PR in an effort to resolve some continued issues with jagged geometries created by snapping buffers that are too large (https://github.com/trailbehind/USFSConflation/issues/74). 

I tested this PR in Yosemite (the area called-out in the USFSConflation issue above) and the buffer size of 0.00005 dramatically reduced the number of jagged roads, but did not eliminate them. 

I'm not sure of a general solution to eliminate these kinds of errors, but at least a smaller buffer appears to have improved the situation. 

This PR also contains a minor update to a debug log string. 